### PR TITLE
chore: fix width of the error notification

### DIFF
--- a/components/simulator/src/components/notification.css
+++ b/components/simulator/src/components/notification.css
@@ -6,6 +6,7 @@
   border-radius: 5px;
   box-shadow: 0 4px 8px #0003;
   opacity: 0.95;
+  width: 600px;
   z-index: 9;
 
   &.middle {
@@ -53,13 +54,14 @@
 
     &.detailed {
       height: 100%;
-      max-height: 150px;
+      max-height: 350px;
       transition: all 500ms ease-in;
     }
 
     .error-details {
       border: 1px dashed #fff5;
       padding: 10px;
+      word-wrap: break-word;
     }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Notifications now display with a fixed width for a consistent look.
	- Expanded detailed views in accordion sections allow more content to be shown.
	- Error messages have improved readability with enhanced text wrapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->